### PR TITLE
Bug k md item keywords string value 83

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 

--- a/README.md
+++ b/README.md
@@ -298,12 +298,23 @@ Options:
   -j, --json                      Print output in JSON format, for use with
                                   --list and --get.
   -X, --wipe                      Wipe all metadata attributes from FILE.
-  -s, --set ATTRIBUTE VALUE       Set ATTRIBUTE to VALUE.
+  -s, --set ATTRIBUTE VALUE       Set ATTRIBUTE to VALUE. If ATTRIBUTE is a
+                                  multi-value attribute, such as keywords
+                                  (kMDItemKeywords), you may specify --set
+                                  multiple times to add to the array of values:
+                                  '--set keywords foo --set keywords bar' will
+                                  set keywords to ['foo', 'bar']. Not that this
+                                  will overwrite any existing values for the
+                                  attribute; see also --append.
   -l, --list                      List all metadata attributes for FILE.
   -c, --clear ATTRIBUTE           Remove attribute from FILE.
   -a, --append ATTRIBUTE VALUE    Append VALUE to ATTRIBUTE; for multi-valued
                                   attributes, appends only if VALUE is not
-                                  already present.
+                                  already present. May be used in combination
+                                  with --set to add to an existing value: '--set
+                                  keywords foo --append keywords bar' will set
+                                  keywords to ['foo', 'bar'], overwriting any
+                                  existing values for the attribute.
   -g, --get ATTRIBUTE             Get value of ATTRIBUTE.
   -r, --remove ATTRIBUTE VALUE    Remove VALUE from ATTRIBUTE; only applies to
                                   multi-valued attributes.

--- a/osxmetadata/__main__.py
+++ b/osxmetadata/__main__.py
@@ -745,7 +745,11 @@ SET_OPTION = click.option(
     "-s",
     "set_",
     metavar="ATTRIBUTE VALUE",
-    help="Set ATTRIBUTE to VALUE.",
+    help="Set ATTRIBUTE to VALUE. "
+    "If ATTRIBUTE is a multi-value attribute, such as keywords (kMDItemKeywords), "
+    "you may specify --set multiple times to add to the array of values: "
+    "'--set keywords foo --set keywords bar' will set keywords to ['foo', 'bar']. "
+    "Not that this will overwrite any existing values for the attribute; see also --append.",
     nargs=2,
     multiple=True,
     required=False,
@@ -788,7 +792,10 @@ APPEND_OPTION = click.option(
     "--append",
     "-a",
     metavar="ATTRIBUTE VALUE",
-    help="Append VALUE to ATTRIBUTE; for multi-valued attributes, appends only if VALUE is not already present.",
+    help="Append VALUE to ATTRIBUTE; for multi-valued attributes, appends only if VALUE is not already present. "
+    "May be used in combination with --set to add to an existing value: "
+    "'--set keywords foo --append keywords bar' will set keywords to ['foo', 'bar'], "
+    "overwriting any existing values for the attribute.",
     nargs=2,
     multiple=True,
     required=False,

--- a/osxmetadata/_version.py
+++ b/osxmetadata/_version.py
@@ -1,3 +1,3 @@
 """ osxmetadata version """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/osxmetadata/osxmetadata.py
+++ b/osxmetadata/osxmetadata.py
@@ -31,7 +31,12 @@ from .finder_info import (
     set_finderinfo_stationerypad,
 )
 from .finder_tags import _kMDItemUserTags, get_finder_tags, set_finder_tags
-from .mditem import MDItemValueType, get_mditem_metadata, set_or_remove_mditem_metadata
+from .mditem import (
+    MDItemValueType,
+    get_mditem_metadata,
+    set_or_remove_mditem_metadata,
+    MDItemSetAttribute,
+)
 from .nsurl_metadata import get_nsurl_metadata, set_nsurl_metadata
 
 ALL_ATTRIBUTES = {
@@ -196,6 +201,34 @@ class OSXMetaData:
                 dict_data[key] = base64.b64encode(value).decode("ascii")
 
         return json.dumps(dict_data, indent=indent)
+
+    def get_mditem_attribute_value(self, attribute: str) -> t.Any:
+        """Get the raw MDItem attribute value without any type conversion.
+
+        Args:
+            attribute: metadata attribute name
+
+        Returns:
+            raw MDItem attribute value as returned by CoreServices.MDItemCopyAttribute()
+
+        Note: This is a low level function that you probably don't need to use,
+        but may be useful in some cases. You should probably use the get() method instead.
+        """
+        return CoreServices.MDItemCopyAttribute(self._mditem, attribute)
+
+    def set_mditem_attribute_value(self, attribute: str, value: t.Any) -> bool:
+        """Set the raw MDItem attribute value without any type conversion.
+
+        Args:
+            attribute: metadata attribute name
+            value: value to set attribute to
+
+        Returns: True if successful otherwise False
+
+        Note: This is a low level function that you probably don't need to use,
+        but may be useful in some cases. You should probably use the set() method instead.
+        """
+        return MDItemSetAttribute(self._mditem, attribute, value)
 
     @property
     def path(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osxmetadata"
-version = "1.2.0"
+version = "1.2.1"
 description = "Read and write meta data, such as tags/keywords, Finder comments, etc. on MacOS files"
 authors = ["Rhet Turnbull <rturnbull+git@gmail.com>"]
 license = "MIT License"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,50 @@ def test_cli_set(test_file):
     assert md.description == "Goodbye World"
 
 
+def test_cli_set_multi_keywords_1(test_file):
+    """Test --set with multiple keywords (#83)"""
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--set",
+            "keywords",
+            "Foo",
+            "--set",
+            "keywords",
+            "Bar",
+            test_file.name,
+        ],
+    )
+    snooze()
+    assert result.exit_code == 0
+    md = OSXMetaData(test_file.name)
+    assert sorted(md.keywords) == ["Bar", "Foo"]
+
+
+def test_cli_set_multi_keywords_2(test_file):
+    """Test --set, --append with multiple keywords (#83)"""
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--set",
+            "keywords",
+            "Foo",
+            "--append",
+            "keywords",
+            "Bar",
+            test_file.name,
+        ],
+    )
+    snooze()
+    assert result.exit_code == 0
+    md = OSXMetaData(test_file.name)
+    assert sorted(md.keywords) == ["Bar", "Foo"]
+
+
 def test_cli_clear(test_file):
     """Test --clear"""
 
@@ -149,6 +193,52 @@ def test_cli_append(test_file):
     assert result.exit_code == 0
     assert md.authors == ["John Doe", "Jane Doe"]
     assert md.tags == [Tag("test", 0)]
+
+
+def test_cli_set_then_append(test_file):
+    """Test --set then --append"""
+
+    md = OSXMetaData(test_file.name)
+    md.authors = ["John Doe"]
+
+    # set initial value
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--set",
+            "keywords",
+            "foo",
+            test_file.name,
+        ],
+    )
+    assert result.exit_code == 0
+
+    # set again and verify that it overwrites
+    result = runner.invoke(
+        cli,
+        [
+            "--set",
+            "keywords",
+            "bar",
+            test_file.name,
+        ],
+    )
+    assert result.exit_code == 0
+    assert md.keywords == ["bar"]
+
+    # append and verify that it appends
+    result = runner.invoke(
+        cli,
+        [
+            "--append",
+            "keywords",
+            "baz",
+            test_file.name,
+        ],
+    )
+    assert result.exit_code == 0
+    assert sorted(md.keywords) == ["bar", "baz"]
 
 
 def test_cli_get(test_file):

--- a/tests/test_mditem_attributes.py
+++ b/tests/test_mditem_attributes.py
@@ -163,3 +163,13 @@ def test_mditem_attributes_audio(test_audio):
 
     md = OSXMetaData(test_audio)
     assert md.get("kMDItemAudioSampleRate") == 44100.0
+
+
+def test_get_set_mditem_attribute_value(test_file):
+    """test get and set of mditem attribute value using the direct methods without value conversion, #83"""
+
+    md = OSXMetaData(test_file.name)
+    md.set_mditem_attribute_value("kMDItemComment", "foo,bar")
+    snooze()
+    assert md.get_mditem_attribute_value("kMDItemComment") == "foo,bar"
+    assert md.comment == "foo,bar"


### PR DESCRIPTION
Bug fix for kMDItemKeywords set to comma delimited string, #83
Fixed documentation for --set, --append, #84 